### PR TITLE
Remove on-failure handler from :cookie/clear, and make on-success optional

### DIFF
--- a/src/com/smxemail/re_frame_cookie_fx.cljs
+++ b/src/com/smxemail/re_frame_cookie_fx.cljs
@@ -151,9 +151,7 @@
 ;; subpath and/or another domain these will still be there.
 (reg-fx
   :cookie/clear
-  (fn [{:keys [on-success on-failure]}]
-    (try
-      (.clear goog.net.cookies)
-      (dispatch on-success)
-      (catch :default e
-        (dispatch (conj on-failure e))))))
+  (fn [& [{:keys [on-success]}]]
+    (.clear goog.net.cookies)
+    (when on-success
+      (dispatch on-success))))


### PR DESCRIPTION
The underlying [clear method](https://google.github.io/closure-library/api/goog.net.Cookies.html) does not throw exceptions. This function should not require using on-success/on-failure handlers. For backwards compatibility this PR maintains the on-success handler support, but since the on-failure hander never is invoked - this PR removes it.